### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -105,6 +105,8 @@ jobs:
 
   audit-licenses:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/typescript-vite-application-template/security/code-scanning/12](https://github.com/digitalservicebund/typescript-vite-application-template/security/code-scanning/12)

To fix the problem, you should explicitly set a `permissions` block for the `audit-licenses` job in `.github/workflows/pipeline.yml`. The minimal recommended starting point is `contents: read`, which limits the job to only read repository contents (the GITHUB_TOKEN will not grant write actions, reducing risk). This change should be made immediately after `runs-on: ubuntu-latest` (line 107), matching the placement and indentation of the existing permissions blocks in other jobs in the workflow file. No new imports or package installations are required, since this is a YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
